### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+FROM centos
+
+RUN yum -y install epel-release && \
+    yum -y update && \
+    yum -y clean all
+
+RUN set -x \
+    && yum -y install \
+        libstdc++ \
+        readline \
+        openssl \
+        yaml \
+        lz4 \
+        binutils \
+        ncurses \
+        libgomp \
+        lua \
+        curl \
+        tar \
+        zip \
+        unzip \
+        libunwind \
+        libcurl \
+        libicu \
+    && yum -y install \
+        perl \
+        gcc-c++ \
+        cmake \
+        readline-devel \
+        openssl-devel \
+        libyaml-devel \
+        lz4-devel \
+        binutils-devel \
+        ncurses-devel \
+        lua-devel \
+        make \
+        git \
+        libunwind-devel \
+        autoconf \
+        automake \
+        libtool \
+        go \
+        wget \
+        curl-devel \
+        libicu-devel \
+    && yum -y install \
+        boost \
+        boost-devel
+
+##
+## Install mysql57 client, devel packages
+##
+RUN yum localinstall -y https://dev.mysql.com/get/mysql80-community-release-el7-1.noarch.rpm \
+    && yum --disablerepo=mysql80-community --enablerepo=mysql57-community install -y \
+        mysql-community-client \
+        mysql-community-devel
+
+
+RUN git clone https://github.com/tarantool/mysql-tarantool-replication.git mysql_tarantool-replication
+
+RUN cd mysql_tarantool-replication \
+    && git submodule update --init --recursive
+
+RUN cd mysql_tarantool-replication \
+    && cmake . \
+    && make
+
+##
+## Copy replicatord binary to new image to minimize size
+##
+FROM centos
+COPY --from=0 mysql_tarantool-replication/replicatord .


### PR DESCRIPTION
Initial effort to build mysql-tarantool-replication replicationd binary.

Mysql source checkout is very very large and performing a shallow clone would be nice but would require libslave referencing an advertised reference such as `mysql-src@mysql-5.7.17` may work instead of `mysql-src@2303280`

Any source or package installation optimizations are beyond my current understanding.

Resulting `replicationd` is present as `/replicationd` in `centos` based Docker image.